### PR TITLE
Suggestion to annotate seas:ConnectionPoint with a unique identifier

### DIFF
--- a/src/main/ontop/1.0/SystemOntology-1.0.ttl
+++ b/src/main/ontop/1.0/SystemOntology-1.0.ttl
@@ -339,7 +339,14 @@ seas:connectsSystemThrough a owl:ObjectProperty ;
   vs:term_status "stable" ;
   rdfs:isDefinedBy seas:SystemOntology .
 
-
+###  https://w3id.org/seas/SystemOntology#hasIdentifier
+:hasIdentifier rdf:type owl:DatatypeProperty ;
+               rdfs:domain seas:ConnectionPoint ;
+               rdfs:range rdfs:Literal ;
+               rdfs:comment "Dataproperty to link identifier to connection point. Identifier may be an arbitrary concatenation of characters."@en ;
+               rdfs:label "Links connection point to identifier."@en ;
+               rdfs:seeAlso "http://purl.org/dc/terms/identifier" .
+  
 
 # specific evaluations
 


### PR DESCRIPTION
Hello everyone!

I would like to propose the introduction of a data property in seas:SystemOntology. The data property is required to annotate a seas:ConnectionPoint with its identifier.

The need for this data property arises from the application of seas ontologies in automation systems. In automation systems arbitrary strings are used to identify datapoints on the automation network ("bus"). Unfortunately I may not be guaranteed that these identifier are valid URI for individuals in an OWL ontology. Hence one cannot use these identifiers as the URI of an individual of seas:ConnectionPoint.

I added a data property accordingly in this pull request. However I would also be happy if a different way to annotate a seas:CommunicationPoint is found.

Best

Georg